### PR TITLE
ENH: Primitive should have IndexStyle IndexLinear()

### DIFF
--- a/src/Arrow.jl
+++ b/src/Arrow.jl
@@ -12,6 +12,7 @@ const ALIGNMENT = 8
 
 import Base: convert, show, unsafe_string, checkbounds, write, values, copy
 import Base: length, endof, size, eltype, start, next, done, getindex, isassigned, view
+import Base: IndexStyle
 import Base: >, ≥, <, ≤, ==
 import Base.isnull # this will be removed in 0.7
 import CategoricalArrays.levels

--- a/src/arrowvectors.jl
+++ b/src/arrowvectors.jl
@@ -256,6 +256,7 @@ done(A::ArrowVector, i::Integer) = i > length(A)
 convert(::Type{Array{T}}, A::ArrowVector{T}) where T = A[:]
 convert(::Type{Vector{T}}, A::ArrowVector{T}) where T = A[:]
 
+IndexStyle(::Type{<:ArrowVector}) = IndexLinear()
 
 # macro for creating arrowformat functions
 macro _formats(constructor, argtype, w...)

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -32,8 +32,6 @@ struct Primitive{J} <: AbstractPrimitive{J}
 end
 export Primitive
 
-IndexStyle(::Type{<:Primitive}) = IndexLinear()
-
 function Primitive{J}(data::Vector{UInt8}, i::Integer, len::Integer) where J
     @boundscheck check_buffer_bounds(J, data, i, len)
     Primitive{J}(len, i, data)

--- a/src/primitives.jl
+++ b/src/primitives.jl
@@ -32,6 +32,8 @@ struct Primitive{J} <: AbstractPrimitive{J}
 end
 export Primitive
 
+IndexStyle(::Type{<:Primitive}) = IndexLinear()
+
 function Primitive{J}(data::Vector{UInt8}, i::Integer, len::Integer) where J
     @boundscheck check_buffer_bounds(J, data, i, len)
     Primitive{J}(len, i, data)


### PR DESCRIPTION
This impacts performance of maps, reductions, and mapreduce:

```
julia> using Arrow, BenchmarkTools

julia> x = rand(10_000);

julia> xa = arrowformat(x);

julia> @benchmark sum(x)
BenchmarkTools.Trial:
  memory estimate:  16 bytes
  allocs estimate:  1
  --------------
  minimum time:     1.174 μs (0.00% GC)
  median time:      1.205 μs (0.00% GC)
  mean time:        1.301 μs (0.00% GC)
  maximum time:     6.949 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10

julia> @benchmark sum(xa)
BenchmarkTools.Trial:
  memory estimate:  16 bytes
  allocs estimate:  1
  --------------
  minimum time:     1.183 μs (0.00% GC)
  median time:      1.209 μs (0.00% GC)
  mean time:        1.275 μs (0.00% GC)
  maximum time:     8.695 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     10

julia> Base.IndexStyle(::Type{<:Arrow.Primitive}) = IndexCartesian()  # reset back to default
WARNING: Method definition (::Type{Base.IndexStyle})(Type{#s10} where #s10<:(Arrow.Primitive{J} where J)) in module Arrow at /Users/sglyon/.julia/v0.6/Arrow/src/primitives.jl:35 overwritten in module Main at REPL[19]:1.

julia> @benchmark sum(xa)
BenchmarkTools.Trial:
  memory estimate:  48 bytes
  allocs estimate:  3
  --------------
  minimum time:     27.531 μs (0.00% GC)
  median time:      27.574 μs (0.00% GC)
  mean time:        29.906 μs (0.00% GC)
  maximum time:     314.118 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1
```