### PR TITLE
fix to copy and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Manifest.toml
 *.jl.cov
 *.jl.*.cov
 *.jl.mem

--- a/Project.toml
+++ b/Project.toml
@@ -6,4 +6,10 @@ version = "0.3.0"
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[targets]
+test = ["Test", "Random"]

--- a/Project.toml
+++ b/Project.toml
@@ -6,3 +6,4 @@ version = "0.3.0"
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,8 @@
+name = "Arrow"
+uuid = "69666777-d1a9-59fb-9406-91d4454c9d45"
+authors = ["ExpandingMan <expandingman@protonmail.com"]
+version = "0.3.0"
+
+[deps]
+CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,0 @@
-julia 0.7
-CategoricalArrays
-Compat 0.66.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/Arrow.jl
+++ b/src/Arrow.jl
@@ -1,30 +1,13 @@
-VERSION < v"0.7.0-beta2.199" && __precompile__()
 module Arrow
 
-using CategoricalArrays, Compat, Compat.Dates
+using CategoricalArrays, Dates
 
 
 const BITMASK = UInt8[1, 2, 4, 8, 16, 32, 64, 128]
 const ALIGNMENT = 8
 
 
-import Base: getindex, setindex!
-import Base: convert, show, unsafe_string, checkbounds, write, values, copy
-import Base: length, size, eltype, getindex, isassigned, view
-import Base: IndexStyle
-import Base: >, ≥, <, ≤, ==
-import CategoricalArrays: levels
-
-
-if VERSION ≥ v"0.7.0-"
-else
-    using Missings
-    import Base: isnull
-end
-
-
 abstract type ArrowVector{T} <: AbstractVector{T} end
-export ArrowVector
 
 
 include("utils.jl")
@@ -35,6 +18,18 @@ include("datetime.jl")
 include("dictencoding.jl")
 include("bitprimitives.jl")
 include("locate.jl")
+
+
+export ArrowVector
+export padding, writepadded, bytesforbits, bitpack, bitpackpadded, unbitpack
+export Primitive, NullablePrimitive, valuesbytes, bitmaskbytes, totalbytes, arrowview
+export List, NullableList, offsetsbytes, offsets, getoffset
+export values, bitmask, offsets, rawvalues, nullcount, isnull, arrowformat, writepadded,
+    rawpadded
+export Timestamp, TimeOfDay, Datestamp
+export DictEncoding, referencetype, references
+export BitPrimitive, NullableBitPrimitive
+export Locate, locate
 
 
 end  # module Arrow

--- a/src/bitprimitives.jl
+++ b/src/bitprimitives.jl
@@ -2,14 +2,12 @@
 # TODO add docs!!!
 
 abstract type AbstractBitPrimitive{J} <: ArrowVector{J} end
-export BitPrimitive
 
 
 struct BitPrimitive <: AbstractBitPrimitive{Bool}
     length::Int64
     values::Primitive{UInt8}  # in principle this can be anything, but don't see the need
 end
-export BitPrimitive
 
 function BitPrimitive(data::Vector{UInt8}, i::Integer, len::Integer)
     BitPrimitive(len, Primitive{UInt8}(data, i, bytesforbits(len)))
@@ -42,7 +40,6 @@ struct NullableBitPrimitive <: AbstractBitPrimitive{Union{Bool,Missing}}
     bitmask::Primitive{UInt8}
     values::Primitive{UInt8}
 end
-export NullableBitPrimitive
 
 function NullableBitPrimitive(data::Vector{UInt8}, bitmask_idx::Integer, values_idx::Integer,
                               len::Integer)

--- a/src/datetime.jl
+++ b/src/datetime.jl
@@ -18,7 +18,6 @@ Timestamp in which time is stored in units `P` as `Int64` for Arrow formatted da
 struct Timestamp{P<:TimePeriod} <: ArrowTime
     value::Int64
 end
-export Timestamp
 
 Timestamp(t::P) where P<:TimePeriod = Timestamp{P}(Dates.value(t))
 Timestamp{P}(t::DateTime) where P<:TimePeriod = convert(Timestamp{P}, t)
@@ -29,18 +28,18 @@ unitvalue(t::Timestamp{P}) where P = P(value(t))
 
 scale(::Type{D}, t::Timestamp{P}) where {D,P} = convert(D, unitvalue(t))
 
-function convert(::Type{DateTime}, t::Timestamp{P}) where P
+function Base.convert(::Type{DateTime}, t::Timestamp{P}) where P
     DateTime(Dates.UTM(UNIXEPOCH_TS + Dates.value(scale(Millisecond, t))))
 end
-convert(::Type{TimeType}, t::Timestamp) = convert(DateTime, t)
+Base.convert(::Type{TimeType}, t::Timestamp) = convert(DateTime, t)
 
-function convert(::Type{Timestamp{P}}, t::DateTime) where P
+function Base.convert(::Type{Timestamp{P}}, t::DateTime) where P
     Timestamp(convert(P, Millisecond(Dates.value(t) - UNIXEPOCH_TS)))
 end
-convert(::Type{Timestamp}, t::DateTime) = convert(Timestamp{Millisecond}, t)
-convert(::Type{ArrowTime}, t::DateTime) = convert(Timestamp, t)
+Base.convert(::Type{Timestamp}, t::DateTime) = convert(Timestamp{Millisecond}, t)
+Base.convert(::Type{ArrowTime}, t::DateTime) = convert(Timestamp, t)
 
-show(io::IO, t::Timestamp) = show(io, convert(DateTime, t))
+Base.show(io::IO, t::Timestamp) = show(io, convert(DateTime, t))
 
 
 """
@@ -52,7 +51,6 @@ Underlying data is `Int32` for seconds and milliseconds, `Int64` for microsecond
 struct TimeOfDay{P<:TimePeriod,T<:Union{Int32,Int64}} <: ArrowTime
     value::T
 end
-export TimeOfDay
 
 function TimeOfDay{P,T}(t::P) where {P<:TimePeriod,T<:Union{Int32,Int64}}
     TimeOfDay{P,T}(Dates.value(convert(P, t)))
@@ -67,17 +65,17 @@ unitvalue(t::TimeOfDay{P}) where P = P(value(t))
 
 scale(::Type{D}, t::TimeOfDay{P}) where {D,P} = convert(D, unitvalue(t))
 
-function convert(::Type{Time}, t::TimeOfDay{P}) where P
+function Base.convert(::Type{Time}, t::TimeOfDay{P}) where P
     Time(Nanosecond(scale(Nanosecond, t)))
 end
-convert(::Type{TimeType}, t::TimeOfDay) = convert(Time, t)
+Base.convert(::Type{TimeType}, t::TimeOfDay) = convert(Time, t)
 
-convert(::Type{TimeOfDay{P,T}}, t::Time) where {P,T} = TimeOfDay{P,T}(convert(P, t.instant))
-convert(::Type{TimeOfDay{P}}, t::Time) where P = TimeOfDay{P}(convert(P, t.instant))
-convert(::Type{TimeOfDay}, t::Time) = convert(TimeOfDay{Nanosecond}, t)
-convert(::Type{ArrowTime}, t::Time) = convert(TimeOfDay, t)
+Base.convert(::Type{TimeOfDay{P,T}}, t::Time) where {P,T} = TimeOfDay{P,T}(convert(P, t.instant))
+Base.convert(::Type{TimeOfDay{P}}, t::Time) where P = TimeOfDay{P}(convert(P, t.instant))
+Base.convert(::Type{TimeOfDay}, t::Time) = convert(TimeOfDay{Nanosecond}, t)
+Base.convert(::Type{ArrowTime}, t::Time) = convert(TimeOfDay, t)
 
-show(io::IO, t::TimeOfDay) = show(io, convert(Time, t))
+Base.show(io::IO, t::TimeOfDay) = show(io, convert(Time, t))
 
 
 """
@@ -88,24 +86,23 @@ Stores a date as an `Int32` for Arrow formatted data.
 struct Datestamp <: ArrowTime
     value::Int32
 end
-export Datestamp
 
 Datestamp(t::Date) = convert(Datestamp, t)
 
 value(t::Datestamp) = t.value
 
-convert(::Type{Date}, t::Datestamp) = Date(Dates.UTD(UNIXEPOCH_DT + value(t)))
-convert(::TimeType, t::Datestamp) = convert(Date, t)
+Base.convert(::Type{Date}, t::Datestamp) = Date(Dates.UTD(UNIXEPOCH_DT + value(t)))
+Base.convert(::TimeType, t::Datestamp) = convert(Date, t)
 
-convert(::Type{Datestamp}, t::Date) = Datestamp(Dates.value(t) - UNIXEPOCH_DT)
-convert(::Type{ArrowTime}, t::Date) = convert(Datestamp, t)
+Base.convert(::Type{Datestamp}, t::Date) = Datestamp(Dates.value(t) - UNIXEPOCH_DT)
+Base.convert(::Type{ArrowTime}, t::Date) = convert(Datestamp, t)
 
-show(io::IO, t::Datestamp) = show(io, convert(Date, t))
+Base.show(io::IO, t::Datestamp) = show(io, convert(Date, t))
 
 
 #======================================================================================================
     some basic utilities for dates and datetimes...
 ======================================================================================================#
-for symb ∈ [:(>), :(≥), :(<), :(≤), :(==)]
-    eval(:($symb(t1::T, t2::T) where T<:ArrowTime = $symb(value(t1), value(t2))))
+for symb ∈ [:(Base.:(>)), :(Base.:(≥)), :(Base.:(<)), :(Base.:(≤)), :(Base.:(==))]
+    @eval $symb(t1::T, t2::T) where {T<:ArrowTime} = $symb(value(t1), value(t2))
 end

--- a/src/dictencoding.jl
+++ b/src/dictencoding.jl
@@ -1,8 +1,6 @@
 
 # TODO is this really a reasonable default way of doing nulls?
 
-import CategoricalArrays.categorical
-
 
 const ReferenceType{J} = AbstractPrimitive{T} where {J<:Integer,T<:Union{J,Union{J,Missing}}}
 
@@ -14,7 +12,6 @@ struct DictEncoding{J,R<:ReferenceType,P<:ArrowVector} <: ArrowVector{J}
     refs::R
     pool::P
 end
-export DictEncoding
 
 function DictEncoding{J}(refs::R, pool::P) where {J,R<:ReferenceType,P<:ArrowVector}
     DictEncoding{J,R,P}(refs, pool)
@@ -80,19 +77,13 @@ DictEncoding{J}(d::DictEncoding{J}) where J = DictEncoding{J}(d.refs, d.pool)
 DictEncoding{J}(d::DictEncoding{T}) where {J,T} = DictEncoding{J}(convert(AbstractVector{J}, d[:]))
 DictEncoding(d::DictEncoding{J}) where J = DictEncoding{J}(d)
 
-
-copy(d::DictEncoding) = DictEncoding(d)
-
+Base.length(d::DictEncoding) = length(d.refs)
 
 referencetype(d::DictEncoding{J,R,P}) where {J,K,R<:ReferenceType{K},P} = K
-export referencetype
 
-
-length(d::DictEncoding) = length(d.refs)
 
 references(d::DictEncoding) = d.refs
-levels(d::DictEncoding) = d.pool
-export references, levels
+CategoricalArrays.levels(d::DictEncoding) = d.pool
 
 
 function createpool(data::Vector{UInt8}, i::Integer, x::CategoricalArray{J,1,U}) where {J,U}
@@ -131,31 +122,31 @@ end
 
 
 # for now this always transfers the entire pool
-function categorical(d::DictEncoding{J,R}, idx::AbstractVector{<:Integer}
+function CategoricalArrays.categorical(d::DictEncoding{J,R}, idx::AbstractVector{<:Integer}
                     ) where {J,K,R<:ReferenceType{K}}
     CategoricalArray{J,1}(_getrefsvec(d, idx), pool(d))
 end
-categorical(d::DictEncoding) = categorical(d, 1:length(d))
+CategoricalArrays.categorical(d::DictEncoding) = categorical(d, 1:length(d))
 
 
-convert(::Type{CategoricalArray}, d::DictEncoding{J,R}) where {J,K,R<:ReferenceType{K}} = categorical(d)
+Base.convert(::Type{CategoricalArray}, d::DictEncoding{J,R}) where {J,K,R<:ReferenceType{K}} = categorical(d)
 
 
-@inline function getindex(d::DictEncoding{J}, i::Integer)::J where J
+@inline function Base.getindex(d::DictEncoding{J}, i::Integer)::J where J
     @boundscheck checkbounds(d, i)
     unsafe_isnull(d, i) ? missing : d.pool[d.refs[i]+1]
 end
-function getindex(d::DictEncoding{J}, idx::AbstractVector{<:Integer}) where J
+function Base.getindex(d::DictEncoding{J}, idx::AbstractVector{<:Integer}) where J
     @boundscheck checkbounds(d, idx)
     @inbounds o = J[getindex(d, i) for i ∈ idx]
     o
 end
-function getindex(d::DictEncoding{J}, idx::AbstractVector{Bool}) where J
+function Base.getindex(d::DictEncoding{J}, idx::AbstractVector{Bool}) where J
     @boundscheck checkbounds(d, idx)
     @inbounds o = J[getindex(d, i) for i ∈ 1:length(d) if idx[i]]
     o
 end
-getindex(d::DictEncoding, ::Colon) = categorical(d)
+Base.getindex(d::DictEncoding, ::Colon) = categorical(d)
 
 
 nullcount(d::DictEncoding{Union{J,Missing}}) where J = nullcount(d.refs)

--- a/src/lists.jl
+++ b/src/lists.jl
@@ -2,7 +2,6 @@
 # TODO bounds checking for all indices
 
 abstract type AbstractList{J} <: ArrowVector{J} end
-export AbstractList
 
 # default offset type to use
 const DefaultOffset = Int32
@@ -47,7 +46,6 @@ struct List{J,K<:Integer,P<:AbstractPrimitive} <: AbstractList{J}
     offsets::Primitive{K}
     values::P
 end
-export List
 
 # Primitive constructors
 function List{J}(len::Integer, offs::Primitive{K}, vals::P) where {J,K<:Integer,P<:AbstractPrimitive}
@@ -120,8 +118,6 @@ List{J}(l::List{J}) where J = List{J}(l.length, l.offsets, l.values)
 List{J}(l::List{T}) where {J,T} = List{J}(convert(AbstractVector{J}, l[:]))
 List(l::List{J}) where J = List{J}(l)
 
-copy(l::List) = List(l)
-
 
 """
     NullableList{P<:AbstractPrimitive,J} <: AbstractList{Union{Missing,J}}
@@ -168,7 +164,6 @@ struct NullableList{J,K<:Integer,P<:AbstractPrimitive} <: AbstractList{Union{Mis
     offsets::Primitive{K}
     values::P
 end
-export NullableList
 
 # Primitive constructors
 function NullableList{J}(len::Integer, bmask::Primitive{UInt8}, offs::Primitive{K},
@@ -259,8 +254,6 @@ NullableList{J}(l::NullableList{J}) where J = NullableList{J}(p.length, p.bitmas
 NullableList{J}(l::NullableList{T}) where {J,T} = NullableList{J}(convert(AbstractVector{J}, p[:]))
 NullableList(l::NullableList{J}) where J = NullableList{J}(l)
 
-copy(l::NullableList) = NullableList(l)
-
 #====================================================================================================
     common interface
 ====================================================================================================#
@@ -275,7 +268,6 @@ bitmaskbytes(A::NullableList) = bytesforbits(length(A))
 offsetsbytes(::Type{K}, len::Integer) where {K<:Integer} = padding((len+1)*sizeof(K))
 offsetsbytes(::Type{K}, A::AbstractVector) where {K<:Integer} = offsetsbytes(K, length(A))
 offsetsbytes(l::AbstractList) = totalbytes(l.offsets)
-export offsetsbytes
 
 function totalbytes(::Type{K}, ::Type{C}, A::AbstractVector) where {K<:Integer,C}
     valuesbytes(C, A) + bitmaskbytes(A) + offsetsbytes(K, A)
@@ -313,7 +305,6 @@ end
 function offsets(v::AbstractVector{<:AbstractString})
     throw(ArgumentError("must specify encoding type for computing string offsets"))
 end
-export offsets
 
 
 function check_offset_bounds(l::AbstractList, i::Integer)
@@ -351,7 +342,6 @@ Retrieve offset `i` for list `l`.  Note that this retrieves the Arrow formated 0
 numbers!
 """
 getoffset(l::AbstractList, i) = l.offsets[i]
-export getoffset
 
 
 """

--- a/src/locate.jl
+++ b/src/locate.jl
@@ -6,10 +6,6 @@ module Locate
     import Arrow
     using Arrow: ALIGNMENT, DefaultOffset
 
-    if VERSION < v"0.7.0-"
-        using Missings
-    end
-
     abstract type Abstract end
 
     function checkalignment(loc::Integer)
@@ -52,7 +48,6 @@ module Locate
     Offsets{J}(x) where {J} = Offsets{J}(offsets(x))
     Offsets(x) = Offsets{DefaultOffset}(offsets(x))
 end
-export Locate
 
 # type constructor methods
 function locate(data::Vector{UInt8}, vals::Locate.Values{J}, len::Integer) where J
@@ -101,5 +96,4 @@ function locate(::Type{NullableBitPrimitive}, data::Vector{UInt8}, ::Type{Union{
     vals = Locate.Values{Bool}(vec)
     NullableBitPrimitive(data, bmask.loc, vals.loc, Locate.length(vec))
 end
-export locate
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,7 +6,6 @@ Determines the total number of bytes needed to store `n` bytes with padding.
 Note that the Arrow standard requires buffers to be aligned to 8-byte boundaries.
 """
 padding(n::Integer) = ((n + ALIGNMENT - 1) ÷ ALIGNMENT)*ALIGNMENT
-export padding
 
 
 paddinglength(n::Integer) = padding(n) - n
@@ -32,7 +31,6 @@ function writepadded(io::IO, x)
     write(io, zeros(UInt8, diff))
     bw + diff
 end
-export writepadded
 
 
 """
@@ -41,7 +39,6 @@ export writepadded
 Get the number of bytes required to store `n` bits.
 """
 bytesforbits(n::Integer) = div(((n + 7) & ~7), 8)
-export bytesforbits
 
 getbit(byte::UInt8, i::Integer) = (byte & BITMASK[i] > 0x00)
 function setbit(byte::UInt8, x::Bool, i::Integer)
@@ -111,7 +108,6 @@ function bitpack(A::AbstractVector{Bool})
     v
 end
 bitpack(A::AbstractVector{Union{Bool,Missing}}) = bitpack(replace_missing_vals(A))
-export bitpack
 
 
 function bitpackpadded(A::AbstractVector{Bool})
@@ -119,7 +115,6 @@ function bitpackpadded(A::AbstractVector{Bool})
     npad = paddinglength(length(v))
     vcat(v, zeros(UInt8, npad))
 end
-export bitpackpadded
 
 
 function bitmaskpadded(A::AbstractVector)
@@ -142,7 +137,6 @@ function unbitpack(A::AbstractVector{UInt8})
     end
     v
 end
-export unbitpack
 
 
 function checkinputsize(v::AbstractVector, idx::AbstractVector{<:Integer})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,6 @@
 using Arrow
-using Compat, Compat.Test, Compat.Random, Compat.Dates
+using Test, Random, Dates
 using CategoricalArrays
-
-if VERSION < v"0.7.0-"
-    using Missings
-end
 
 const ≅ = isequal
 
@@ -22,11 +18,7 @@ const MAX_STRING_LENGTH = 32
 const PRIMITIVE_ELTYPES = [Float32, Float64, Int32, Int64, UInt16]
 const OFFSET_ELTYPES = [Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64]
 
-if VERSION < v"0.7-"
-    Compat.Random.srand(SEED)
-else
-    Compat.Random.seed!(SEED)
-end
+Random.seed!(SEED)
 
 include("testutils.jl")
 


### PR DESCRIPTION
This fixes #35 and cleans up various things:
- Drop support for pre-1.0.
- Explicitly extend functions from `Base` rather than using `import`.
- Put exports in a sane place rather than sprinkling them unpredictably throughout the whole damn package.
- Added a `Project.toml` and removed `REQUIRE`.

Once this gets merged, I will tag it as 0.3.0.
