### PR TITLE
Fix Inefficient String Encoding

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -96,10 +96,6 @@ function encode(::Type{C}, v::AbstractVector{Union{J, Missing}}) where {C, J <: 
 end
 
 
-
-function myencode(::Type{UInt8}, x::Vector{J}) where {J <: AbstractString}
-end
-
 function replace_missing_vals(A::AbstractVector{Union{J,Missing}}) where J<:Number
     J[ismissing(x) ? zero(J) : x for x ∈ A]
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -69,6 +69,36 @@ function encode(::Type{C}, v::AbstractVector{Union{J,Missing}}) where {C,J}
     end
 end
 
+function encode(::Type{C}, v::AbstractVector{J}) where {C, J <: AbstractString}
+    N   = mapreduce(length ∘ codeunits, +, v)
+    enc = Vector{C}(undef, N)
+    i   = 0
+    for val in v, c in codeunits(val)
+       i += 1
+       enc[i] = convert(C, c)
+    end
+    return enc
+end
+
+function encode(::Type{C}, v::AbstractVector{Union{J, Missing}}) where {C, J <: AbstractString}
+    N   = mapreduce(x -> ismissing(x) ? 0 : length(codeunits(x)) , +, v)
+    enc = Vector{C}(undef, N)
+    i   = 0
+    for val in v
+        if !ismissing(val)
+            for c in codeunits(val)
+                i += 1
+                enc[i] = convert(C, c)
+            end
+        end
+    end
+    return enc
+end
+
+
+
+function myencode(::Type{UInt8}, x::Vector{J}) where {J <: AbstractString}
+end
 
 function replace_missing_vals(A::AbstractVector{Union{J,Missing}}) where J<:Number
     J[ismissing(x) ? zero(J) : x for x ∈ A]


### PR DESCRIPTION
The code for constructing `List(v::Vector{String})` is extremely slow, causing problems when writing Feather files of dataframes that are string heavy (for instance, it took me 770s to write a 3.2GB file with a large number of address fields, whereas python can write the same file in 12s).  It looks like the problem comes from the code that [encodes](https://github.com/ExpandingMan/Arrow.jl/blob/94b335e209485b15163af974e6cb58bd34632e76/src/utils.jl#L63)  the strings as vectors of `UInt8`.  

I played around with it, and it looks like you can get nearly a 20X speedup by writing a specialized method to handle vectors of strings as in this PR:
```julia
julia> using Arrow, BenchmarkTools
julia> x = repeat(["a", "b", "c"].^10, 5_000_000);
# Before this PR
julia> @btime arrowformat($x)
  8.794 s (45016393 allocations: 69.95 GiB)
# After this PR
julia> @btime arrowformat($x)
  463.789 ms (13 allocations: 400.54 MiB)
```
I'm not super familiar with the internals of string encodings, but this seems to work on my local machine (and passes all the tests).  I've tried it out with Feather as well on some real world datasets, and everything seems to work properly.  

