### PR TITLE
replaced `get_levels(x)` to `levels(x)`

### DIFF
--- a/src/dictencoding.jl
+++ b/src/dictencoding.jl
@@ -35,13 +35,13 @@ end
 function DictEncoding(data::Vector{UInt8}, refs_idx::Integer, pool_idx::Integer,
                       x::CategoricalArray{J,1,U}) where {J,U}
     refs = Primitive{Int32}(data, refs_idx, getrefs(x))
-    pool = Primitive{J}(data, pool_idx, getlevels(x))
+    pool = Primitive{J}(data, pool_idx, levels(x))
     DictEncoding{J}(refs, pool)
 end
 function DictEncoding(data::Vector{UInt8}, refs_bmask_idx::Integer, refs_values_idx::Integer,
                       pool_idx::Integer, x::CategoricalArray{Union{J,Missing},1,U}) where {J,U}
     refs = NullablePrimitive{Int32}(data, refs_bmask_idx, refs_values_idx, getrefs(x))
-    pool = Primitive{J}(data, pool_idx, getlevels(x))
+    pool = Primitive{J}(data, pool_idx, levels(x))
     DictEncoding{J}(refs, pool)
 end
 
@@ -65,7 +65,7 @@ end
 
 function DictEncoding(x::CategoricalArray{J,1,U}) where {J,U}
     refs = arrowformat(getrefs(x))
-    pool = arrowformat(getlevels(x))
+    pool = arrowformat(levels(x))
     DictEncoding{J}(refs, pool)
 end
 
@@ -87,11 +87,11 @@ CategoricalArrays.levels(d::DictEncoding) = d.pool
 
 
 function createpool(data::Vector{UInt8}, i::Integer, x::CategoricalArray{J,1,U}) where {J,U}
-    Primitive{J}(data, i, getlevels(x))
+    Primitive{J}(data, i, levels(x))
 end
 function createpool(data::Vector{UInt8}, i::Integer, x::CategoricalArray{T,1,U}
                    ) where {J<:AbstractString,U,T<:Union{J,Union{J,Missing}}}
-    List{J}(data, i, getlevels(x))
+    List{J}(data, i, levels(x))
 end
 
 
@@ -164,7 +164,7 @@ function getrefs(x::CategoricalArray{Union{J,Missing},1,U}) where {J,U}
     refs
 end
 
-getlevels(x::CategoricalArray) = x.pool.index
+
 
 refsbytes(len::Integer) = padding(sizeof(Int32)*len)
 refsbytes(::Type{Union{J,Missing}}, len::Integer) where J = bitmaskbytes(len) + refsbytes(len)
@@ -172,8 +172,8 @@ refsbytes(x::AbstractVector) = refsbytes(length(x))
 refsbytes(::Type{Union{J,Missing}}, x::AbstractVector) where J = refsbytes(Union{J,Missing}, length(x))
 refsbytes(x::AbstractVector{Union{J,Missing}}) where J = refsbytes(Union{J,Missing}, length(x))
 
-totalbytes(x::CategoricalArray) = refsbytes(x) + totalbytes(getlevels(x))
+totalbytes(x::CategoricalArray) = refsbytes(x) + totalbytes(levels(x))
 function totalbytes(x::CategoricalArray{Union{J,Missing},1,U}) where {J,U}
-    refsbytes(Union{J,Missing}, x) + totalbytes(getlevels(x))
+    refsbytes(Union{J,Missing}, x) + totalbytes(levels(x))
 end
 

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -375,7 +375,7 @@ end
     pool = CategoricalPool{Int,Int32}([-999, 55, 42])
     ref = CategoricalArray{Union{Int,Missing},1}(Int32[1,0,2,1,3], pool)
     @test typeof(d.refs) == NullablePrimitive{Int32}
-    @test typeof(d.pool) == Primitive{Int64}
+    @test typeof(d.pool) == Primitive{Int}
     @test d[1] == -999
     @test ismissing(d[2])
     @test d[3] == 55


### PR DESCRIPTION
Resolves #51 

- Replaced all instances of `get_levels(x)` with `levels(x)` 
- Removed `get_levels(x::CategoricalArray)` 

 unit test results : 
```
(Arrow) pkg> test Arrow
    Testing Arrow
Status `<path>\AppData\Local\Temp\jl_RHRSlu\Manifest.toml`
  [69666777] Arrow v0.2.4 [`<path>\.julia\dev\Arrow`]
  [324d7699] CategoricalArrays v0.8.1
  [9a962f9c] DataAPI v1.3.0
  [682c06a0] JSON v0.21.0
  [e1d29d7a] Missings v0.4.3
  [69de0a69] Parsers v1.0.4
  [2a0f44e3] Base64
  [ade2ca70] Dates
  [8ba89e20] Distributed
  [9fa8497b] Future
  [b77e0a4c] InteractiveUtils
  [8f399da3] Libdl
  [37e2e46d] LinearAlgebra
  [56ddb016] Logging
  [d6f4376e] Markdown 
  [a63ad114] Mmap
  [de0858da] Printf
  [9a3f8284] Random
  [9e88b42a] Serialization
  [6462fe0b] Sockets
  [2f01184e] SparseArrays
  [10745b16] Statistics
  [8dfed614] Test
  [4ec0a83e] Unicode
Test Summary:             | Pass  Total
indexing_Primitive_buffer |  260    260
Test Summary:                | Pass  Total
indexing_Primitive_construct |  260    260
Test Summary:               | Pass  Total
indexing_Primitive_setindex |  384    384
Test Summary:            | Pass  Total
indexing_Primitive_empty |    8      8
Test Summary:                     | Pass  Total
indexing_NullablePrimitive_buffer |  260    260
Test Summary:                        | Pass  Total
indexing_NullablePrimitive_construct |  260    260
Test Summary:                       | Pass  Total
indexing_NullablePrimitive_setindex |  384    384
Test Summary:                    | Pass  Total
indexing_NullablePrimitive_empty |    8      8
Test Summary:        | Pass  Total
indexing_List_buffer |   10     10
Test Summary:           | Pass  Total
indexing_List_construct |  260    260
Test Summary:       | Pass  Total
indexing_List_empty |    4      4
Test Summary:                | Pass  Total
indexing_NullableList_buffer |   12     12
Test Summary:                   | Pass  Total
indexing_NullableList_construct |  260    260
Test Summary:               | Pass  Total
indexing_NullableList_empty |    4      4
Test Summary:                | Pass  Total
indexing_BitPrimitive_buffer |   65     65
Test Summary:                   | Pass  Total
indexing_BitPrimitive_construct |  260    260
Test Summary:                        | Pass  Total
indexing_NullableBitPrimitive_buffer |   65     65
Test Summary:                           | Pass  Total
indexing_NullableBitPrimitive_construct |  260    260
Test Summary:                | Pass  Total
indexing_DictEncoding_buffer |   12     12
Test Summary:                   | Pass  Total
indexing_DictEncoding_construct |   11     11
Test Summary:    | Pass  Total
wrinting_padding |   64     64
writing_Primitive |   48     48
Test Summary:             | Pass  Total
writing_NullablePrimitive |   48     48
Test Summary: | Pass  Total
writing_List  |   48     48
locate        |    6      6
Test Summary: | Pass  Total
Test Summary:         | Pass  Total
arrowformat_construct |   13     13
    Testing Arrow tests passed
```
